### PR TITLE
[FEAT] Security improvements, SMTP with TLS, disable kDHE

### DIFF
--- a/roles/mailserver/bootstrap/tasks/main.yml
+++ b/roles/mailserver/bootstrap/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Test if vault password can be decrypted
+  set_fact:
+    test_var_password: "{{ mail_password }}"
+  no_log: True
+
 - name: Update apt cache
   apt: update_cache=yes
 

--- a/roles/mailserver/dovecot/templates/10-master.conf.jinja2
+++ b/roles/mailserver/dovecot/templates/10-master.conf.jinja2
@@ -130,5 +130,6 @@ service dict {
 service managesieve-login {
     inet_listener sieve {
         port = 4190
+        address = 127.0.0.1
     }
 }

--- a/roles/mailserver/nginx/tasks/main.yml
+++ b/roles/mailserver/nginx/tasks/main.yml
@@ -19,6 +19,13 @@
     dest: "/etc/nginx/sites-enabled/mail.{{ mail_domain }}"
     state: link
 
+- name: Configure safe SSL ciphers for nginx
+  lineinfile:
+    dest: "/etc/nginx/nginx.conf"
+    insertafter: 'ssl_prefer_server_ciphers'
+    line: "        ssl_ciphers ECDH+AESGCM:ECDH+AES256:ECDH+AES128:DH+3DES:!ADH:!AECDH:!MD5:!kDHE;"
+
+
 - name: Extract base website into /var/www/html
   unarchive:
     src: website.tar

--- a/roles/mailserver/nginx/templates/domain.jinja2
+++ b/roles/mailserver/nginx/templates/domain.jinja2
@@ -10,9 +10,9 @@ server
    server_name www.{{ mail_domain }} {{ mail_domain }};
    index index.php index.html index.htm;
    root /var/www/html/;
-   ssl on;
    ssl_certificate /etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/{{ mail_domain }}/privkey.pem;
+   ssl_protocols TLSv1.2 TLSv1.3;
 }
 
 server
@@ -21,9 +21,9 @@ server
    server_name mail.{{ mail_domain }};
 
    root /usr/lib/GNUstep/SOGo/WebServerResources/;
-   ssl on;
    ssl_certificate /etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/{{ mail_domain }}/privkey.pem;
+   ssl_protocols TLSv1.2 TLSv1.3;
    ## requirement to create new calendars in Thunderbird ##
    proxy_http_version 1.1;
 

--- a/roles/mailserver/postfix/templates/main.cf.jinja2
+++ b/roles/mailserver/postfix/templates/main.cf.jinja2
@@ -19,12 +19,31 @@ readme_directory = no
 # TLS parameters
 smtpd_tls_cert_file=/etc/letsencrypt/live/{{ mail_domain }}/fullchain.pem
 smtpd_tls_key_file=/etc/letsencrypt/live/{{ mail_domain }}/privkey.pem
+# smtp_use_tls = yes
 smtpd_use_tls=yes
 smtpd_tls_auth_only = yes
 smtp_tls_security_level = may
-smtpd_tls_security_level = may
+smtpd_tls_security_level = encrypt
+smtpd_client_new_tls_session_rate_limit = 100
 smtpd_sasl_security_options = noanonymous, noplaintext
 smtpd_sasl_tls_security_options = noanonymous
+
+# tls_random_source = dev:/dev/urandom
+
+smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3
+smtpd_tls_protocols = !SSLv2, !SSLv3
+smtp_tls_mandatory_protocols = !SSLv2, !SSLv3
+smtp_tls_protocols = !SSLv2, !SSLv3
+
+smtp_tls_exclude_ciphers = EXP, MEDIUM, LOW, DES, 3DES, SSLv2
+smtpd_tls_exclude_ciphers = EXP, MEDIUM, LOW, DES, 3DES, SSLv2
+
+tls_high_cipherlist = kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!RC4:!MD5:!DES:!EXP:!SEED:!IDEA:!3DES
+tls_medium_cipherlist = kEECDH:+kEECDH+SHA:kEDH:+kEDH+SHA:+kEDH+CAMELLIA:kECDH:+kECDH+SHA:kRSA:+kRSA+SHA:+kRSA+CAMELLIA:!aNULL:!eNULL:!SSLv2:!MD5:!DES:!EXP:!SEED:!IDEA:!3DES:!kDHE
+
+smtp_tls_ciphers = high
+smtpd_tls_ciphers = high
+
 
 # Authentication
 smtpd_sasl_type = dovecot

--- a/roles/mailserver/setpasswords/tasks/main.yml
+++ b/roles/mailserver/setpasswords/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 - name: Set root DB password, or generate a random one if it doesn't exist
   set_fact:
-    root_db_password: "{{ lookup('password', '' + secretpath + '/root_db_password length=32 chars=ascii_letters,digits') }}"
+    root_db_password: "{{ lookup('password', '' + secretpath + '/' + mail_domain + '_root_db_password length=32 chars=ascii_letters,digits') }}"
   no_log: True
 
 - name: Set vmail DB user password, or generate a random one if it doesn't exist
   set_fact:
-    vmail_db_password: "{{ lookup('password', '' + secretpath + '/vmail_db_password length=32 chars=ascii_letters,digits') }}"
+    vmail_db_password: "{{ lookup('password', '' + secretpath + '/' + mail_domain + '_vmail_db_password length=32 chars=ascii_letters,digits') }}"
   no_log: True
 
 - name: Set sogo DB user password, or generate a random one if it doesn't exist
   set_fact:
-    sogo_db_password: "{{ lookup('password', '' + secretpath + '/sogo_db_password length=32 chars=ascii_letters,digits') }}"
+    sogo_db_password: "{{ lookup('password', '' + secretpath + '/' + mail_domain + '_sogo_db_password length=32 chars=ascii_letters,digits') }}"
   no_log: True
   when: sogo | default('true')  == 'true'

--- a/roles/mailserver/sogo/tasks/main.yml
+++ b/roles/mailserver/sogo/tasks/main.yml
@@ -19,6 +19,12 @@
     dest: /etc/sogo/sogo.conf
   no_log: True
 
+- name: Sogo increase WOWorkersCount from default of 3
+  lineinfile:
+    dest: /etc/default/sogo
+    line: "PREFORK=8"
+    state: present
+
 - name: Restart sogo services
   service:
     name: "{{ item }}"

--- a/roles/mailserver/sogo/templates/sogo.conf.jinja2
+++ b/roles/mailserver/sogo/templates/sogo.conf.jinja2
@@ -15,7 +15,8 @@
 
     // Daemon address and port
     WOPort = 127.0.0.1:20000;
-    WOWorkersCount = 100;
+    // WOWorkersCount below is managed in /etc/default/sogo with PREFORK
+    WOWorkersCount = 8;
     SxVMemLimit = 384;
     SOGoMaximumPingInterval = 3540;
     SOGoInternalSyncInterval = 45;
@@ -71,8 +72,8 @@
 
     // SMTP server
     SOGoMailingMechanism = smtp;
-    SOGoSMTPServer = 127.0.0.1;
-    //SOGoSMTPAuthenticationType = PLAIN;
+    SOGoSMTPServer = "smtp://{{ mail_domain }}:587/?tls=YES";
+    SOGoSMTPAuthenticationType = PLAIN;
 
     // Enable managesieve service
     //


### PR DESCRIPTION
- Postfix uses TLS by default and requires encryption. Diffie-Hellman disabled as cipher. Sogo uses TLS too.
- Nginx forces usage of tls 1.2 or 1.3, Diffie-Hellman disabled.
- Sieve listens only on localhost (port 4190). I'm not sure if this limits some sort of functionality, but Sogo still works.
- Minor tweaks